### PR TITLE
chore: Try the new preview linux aarch 64 runner

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,6 +52,11 @@ jobs:
             runner: ubuntu-latest
             tag: linux-amd64
             ignore-errors: false
+          - os: linux
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+            tag: linux-aarch64
+            ignore-errors: false
           - os: macos
             runner: macos-latest
             arch: amd64


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners